### PR TITLE
feat(nextdns): add configurable TTL and cache to nextdns

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ services:
       NEXTDNS_CONFIG_YOUR_CUSTOM_SUFFIX: <<Your conditional routing pattern here. Documentation here: https://github.com/nextdns/nextdns/wiki/Conditional-Configuration>
       NEXTDNS_FORWARDING_DOMAIN: <<Your Local DNS Name Here, eg: myfancyhome.net>>
       NEXTDNS_FORWARDING_DNSIP: <<Your Local Router's IP Here, eg: 10.0.1.1>>
+      NEXTDNS_MAX_TTL: <<Maximum TTL in seconds for hostnames from NextDNS - defaults to 15>>
+      NEXTDNS_CACHE_SIZE: <<Cache size for NextDNS - defaults to 10MB>>
     restart: always
 ```
 

--- a/nextdns-proxy/run.sh
+++ b/nextdns-proxy/run.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+NEXTDNS_MAX_TTL=${NEXTDNS_MAX_TTL:-15}
+NEXTDNS_CACHE_SIZE=${NEXTDNS_CACHE_SIZE:-10MB}
 NEXTDNS_CONFIG_ID=$NEXTDNS_CONFIG
-NEXTDNS_ARGUMENTS="-listen :8053 -report-client-info -log-queries -cache-size=10MB -max-ttl=15s"
-
+NEXTDNS_ARGUMENTS="-listen :8053 -report-client-info -log-queries -cache-size=${NEXTDNS_CACHE_SIZE} -max-ttl=${NEXTDNS_MAX_TTL}s"
 /etc/init.d/dnsmasq restart
 
 echo "Parsing configuration"


### PR DESCRIPTION
This brings in two new configuration parameters, `NEXTDNS_MAX_TTL` and
`NEXTDNS_CACHE_SIZE` as optional parameters for configuring the NextDNS
CLI.

`NEXTDNS_MAX_TTL`: the maximum TTL for domains returned by NextDNS in
seconds. This defaults to `15`, but can be set higher particularly if
you've got caching layers elsewhere in your stack.

`NEXTDNS_CACHE_SIZE`: the size of NextDNS cache. Most systems should not
need to change this. It defaults to `10MB` - note that this requires a
unit.

Both are set as environment variables that can be imported by the
container.

DCO-1.1-Signed-off-by: Patrick Wagstrom <patrick@wagstrom.net>